### PR TITLE
Added fuction for sending console data over CRTP or CPX

### DIFF
--- a/src/bl.c
+++ b/src/bl.c
@@ -236,7 +236,7 @@ void bl_boot_to_application(void) {
   DEBUG_PRINTF("Entrypoint base?: 0x%X\n", header.entryBase);
 
   if (header.nSegments == 0 || header.nSegments > MAX_NB_SEGMENT) {
-    printf("Binary header seems not ok, not jumping to application\n");
+    cpxPrintToConsole(LOG_TO_CRTP, "Binary application header doesn't seem ok, not exiting bootloader\n");
     return;
   }
 

--- a/src/cpx.c
+++ b/src/cpx.c
@@ -58,6 +58,22 @@ uint32_t cpxReceivePacketBlocking(CPXPacket_t * packet) {
   return size;
 }
 
+static CPXPacket_t consoleTx;
+void cpxPrintToConsole(CPXConsoleTarget_t target, const char * fmt, ...) {
+  va_list ap;
+  int len;
+
+  va_start(ap, fmt);
+  len = vsnprintf(consoleTx.data, sizeof(consoleTx.data), fmt, ap);
+  va_end(ap);
+
+  consoleTx.route.destination = target;
+  consoleTx.route.source = GAP8;
+  consoleTx.route.function = CONSOLE;
+
+  cpxSendPacketBlocking(&consoleTx, len + 1);
+}
+
 void cpxSendPacketBlocking(CPXPacket_t * packet, uint32_t size) {
   /*ASSERT((packet->route.destination >> 4) == 0);
   ASSERT((packet->route.source >> 4) == 0);

--- a/src/cpx.h
+++ b/src/cpx.h
@@ -51,6 +51,11 @@ typedef enum {
   BOOTLOADER = 0x0F,
 } CPXFunction_t;
 
+typedef enum {
+  LOG_TO_WIFI = HOST,
+  LOG_TO_CRTP = STM32
+} CPXConsoleTarget_t;
+
 typedef struct {
   CPXTarget_t destination;
   CPXTarget_t source;
@@ -66,3 +71,5 @@ typedef struct {
 uint32_t cpxReceivePacketBlocking(CPXPacket_t * packet);
 
 void cpxSendPacketBlocking(CPXPacket_t * packet, uint32_t size);
+
+void cpxPrintToConsole(CPXConsoleTarget_t target, const char * fmt, ...);


### PR DESCRIPTION
This adds functionality to send console logs over CPX, either via WiFi or via CRTP.

The only current printout is if the binary header of the application seems corrupt and the application will not be started.