### PR TITLE
Fix the CPX send size being capped to 1 byte

### DIFF
--- a/src/cpx.c
+++ b/src/cpx.c
@@ -80,7 +80,7 @@ void cpxSendPacketBlocking(CPXPacket_t * packet, uint32_t size) {
   ASSERT((packet->route.function >> 8) == 0);
   ASSERT(size <= MTU - CPX_HEADER_SIZE);*/
 
-  txp.length = (uint8_t) size + CPX_HEADER_SIZE;
+  txp.length = (uint16_t) size + CPX_HEADER_SIZE;
   txp.cpxDst = packet->route.destination;
   txp.cpxSrc = packet->route.source;
   txp.cpxFunc = packet->route.function;


### PR DESCRIPTION
This fixes the error where the CPX send function limits the size of the length field to 1 byte when it should be 2. This only effected reading back data from the bootloader.